### PR TITLE
Add support for database

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,10 @@ dependencies {
     implementation libs.lifecycle.viewmodel.ktx
     implementation libs.navigation.fragment
     implementation libs.navigation.ui
+    implementation libs.room.common
+    implementation libs.room.runtime
     testImplementation libs.junit
     androidTestImplementation libs.ext.junit
     androidTestImplementation libs.espresso.core
+    annotationProcessor libs.room.compiler
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".CaltrackApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/teamfive/caltrack/CaltrackApplication.java
+++ b/app/src/main/java/com/teamfive/caltrack/CaltrackApplication.java
@@ -1,0 +1,22 @@
+package com.teamfive.caltrack;
+
+import android.app.Application;
+import androidx.room.Room;
+
+import com.teamfive.caltrack.database.AppDatabase;
+
+public class CaltrackApplication extends Application {
+
+    private static AppDatabase database;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        database = Room.databaseBuilder(getApplicationContext(),
+                AppDatabase.class, "logsDatabase").build();
+    }
+
+    public static AppDatabase getDatabase() {
+        return database;
+    }
+}

--- a/app/src/main/java/com/teamfive/caltrack/MainActivity.java
+++ b/app/src/main/java/com/teamfive/caltrack/MainActivity.java
@@ -10,6 +10,8 @@ import androidx.navigation.Navigation;
 import androidx.navigation.ui.AppBarConfiguration;
 import androidx.navigation.ui.NavigationUI;
 
+import com.teamfive.caltrack.database.AppDatabase;
+import com.teamfive.caltrack.database.entities.Goals;
 import com.teamfive.caltrack.databinding.ActivityMainBinding;
 
 public class MainActivity extends AppCompatActivity {

--- a/app/src/main/java/com/teamfive/caltrack/database/AppDatabase.java
+++ b/app/src/main/java/com/teamfive/caltrack/database/AppDatabase.java
@@ -1,0 +1,23 @@
+package com.teamfive.caltrack.database;
+
+import androidx.room.Database;
+import androidx.room.RoomDatabase;
+import androidx.room.TypeConverters;
+
+import com.teamfive.caltrack.database.dao.DailyLogsDao;
+import com.teamfive.caltrack.database.dao.FoodLogsDao;
+import com.teamfive.caltrack.database.dao.GoalsDao;
+import com.teamfive.caltrack.database.entities.DailyLog;
+import com.teamfive.caltrack.database.entities.FoodLog;
+import com.teamfive.caltrack.database.entities.Goals;
+import com.teamfive.caltrack.database.helpers.Converters;
+
+
+@Database(entities = {DailyLog.class, FoodLog.class, Goals.class}, version = 1, exportSchema = false)
+@TypeConverters({Converters.class})
+public abstract class AppDatabase extends RoomDatabase {
+
+    public abstract DailyLogsDao dailyLogsDao();
+    public abstract FoodLogsDao foodLogsDao();
+    public abstract GoalsDao goalsDao();
+}

--- a/app/src/main/java/com/teamfive/caltrack/database/dao/DailyLogsDao.java
+++ b/app/src/main/java/com/teamfive/caltrack/database/dao/DailyLogsDao.java
@@ -1,0 +1,24 @@
+package com.teamfive.caltrack.database.dao;
+
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.Query;
+
+import com.teamfive.caltrack.database.entities.DailyLog;
+
+import java.util.Date;
+import java.util.List;
+
+@Dao
+public interface DailyLogsDao {
+
+    @Insert
+    void insertDailyLog(DailyLog dailyLog);
+
+    @Query("SELECT * FROM daily_logs WHERE date = :date")
+    DailyLog getDailyLogByDate(Date date);
+
+    @Delete
+    void deleteDailyLog(DailyLog dailyLog);
+}

--- a/app/src/main/java/com/teamfive/caltrack/database/dao/FoodLogsDao.java
+++ b/app/src/main/java/com/teamfive/caltrack/database/dao/FoodLogsDao.java
@@ -1,0 +1,26 @@
+package com.teamfive.caltrack.database.dao;
+
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.Query;
+
+import com.teamfive.caltrack.database.entities.DailyLog;
+import com.teamfive.caltrack.database.entities.FoodLog;
+
+import java.util.Date;
+import java.util.List;
+
+@Dao
+public interface FoodLogsDao {
+
+    @Insert
+    void insertFoodLog(FoodLog foodLog);
+
+    @Query("SELECT * FROM food_logs WHERE date = :date")
+    List<FoodLog> getFoodLogsByDate(Date date);
+
+    @Delete
+    void deleteDailyLog(DailyLog dailyLog);
+
+}

--- a/app/src/main/java/com/teamfive/caltrack/database/dao/GoalsDao.java
+++ b/app/src/main/java/com/teamfive/caltrack/database/dao/GoalsDao.java
@@ -1,0 +1,47 @@
+package com.teamfive.caltrack.database.dao;
+
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.Query;
+import androidx.room.Transaction;
+
+import com.teamfive.caltrack.database.entities.Goals;
+
+import java.util.Date;
+
+@Dao
+public interface GoalsDao {
+
+
+    /**
+     * NOTE: This method should never be used directly, it is a helper function for the
+     * updateActiveGoalAndInsertNew method which nullifies the previous goal and inserts a new
+     * one.
+     * @param newStartDate
+     */
+    @Query("UPDATE goals SET end_date = :newStartDate WHERE end_date IS NULL")
+    void setEndDateForActiveGoal(Date newStartDate);
+
+    /**
+     * NOTE: This method should never be used directly, it is a helper function for the
+     * updateActiveGoalAndInsertNew method which nullifies the previous goal and inserts a new
+     * one.
+     * @param goals
+     */
+    @Insert
+    void insertGoal(Goals goals);
+
+    /**
+     * This method nullifies the end_date of the previous goal and inserts a new date. It should
+     * never be null.
+     * @param newGoal
+     */
+    @Transaction
+    default void updateActiveGoalAndInsertNew(Goals newGoal) {
+        // Step 1: Use newGoal's start_date as the end_date for the current active goal
+        setEndDateForActiveGoal(newGoal.getStartDate());
+
+        // Step 2: Insert the new goal with start_date set to newGoal's start_date
+        insertGoal(newGoal);
+    }
+}

--- a/app/src/main/java/com/teamfive/caltrack/database/entities/DailyLog.java
+++ b/app/src/main/java/com/teamfive/caltrack/database/entities/DailyLog.java
@@ -1,0 +1,84 @@
+package com.teamfive.caltrack.database.entities;
+
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+import java.util.Date;
+
+@Entity(tableName = "daily_logs")
+public class DailyLog {
+
+    @PrimaryKey(autoGenerate = true)
+    private int id;
+
+    private Date date;
+    private String journal;
+    private int goalCalories;
+    private int goalCarbs;
+    private int goalFat;
+    private int goalProtein;
+
+    public DailyLog(Date date, int goalCalories, int goalCarbs, int goalFat, int goalProtein) {
+        this.date = date;
+        this.journal = "";
+        this.goalCalories = goalCalories;
+        this.goalCarbs = goalCarbs;
+        this.goalFat = goalFat;
+        this.goalProtein = goalProtein;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
+    public String getJournal() {
+        return journal;
+    }
+
+    public void setJournal(String journal) {
+        this.journal = journal;
+    }
+
+    public int getGoalCalories() {
+        return goalCalories;
+    }
+
+    public void setGoalCalories(int goalCalories) {
+        this.goalCalories = goalCalories;
+    }
+
+    public int getGoalCarbs() {
+        return goalCarbs;
+    }
+
+    public void setGoalCarbs(int goalCarbs) {
+        this.goalCarbs = goalCarbs;
+    }
+
+    public int getGoalFat() {
+        return goalFat;
+    }
+
+    public void setGoalFat(int goalFat) {
+        this.goalFat = goalFat;
+    }
+
+    public int getGoalProtein() {
+        return goalProtein;
+    }
+
+    public void setGoalProtein(int goalProtein) {
+        this.goalProtein = goalProtein;
+    }
+}

--- a/app/src/main/java/com/teamfive/caltrack/database/entities/FoodLog.java
+++ b/app/src/main/java/com/teamfive/caltrack/database/entities/FoodLog.java
@@ -1,0 +1,85 @@
+// FoodLog.java
+package com.teamfive.caltrack.database.entities;
+
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+
+import java.util.Date;
+
+@Entity(tableName = "food_logs")
+public class FoodLog {
+
+    @PrimaryKey(autoGenerate = true)
+    private int id;
+
+    private Date date;
+    private String name;
+    private int calories;
+    private int carbs;
+    private int fat;
+    private int protein;
+
+    public FoodLog(String name, int calories, int carbs, int fat, int protein) {
+        this.name = name;
+        this.calories = calories;
+        this.carbs = carbs;
+        this.fat = fat;
+        this.protein = protein;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getCalories() {
+        return calories;
+    }
+
+    public void setCalories(int calories) {
+        this.calories = calories;
+    }
+
+    public int getCarbs() {
+        return carbs;
+    }
+
+    public void setCarbs(int carbs) {
+        this.carbs = carbs;
+    }
+
+    public int getFat() {
+        return fat;
+    }
+
+    public void setFat(int fat) {
+        this.fat = fat;
+    }
+
+    public int getProtein() {
+        return protein;
+    }
+
+    public void setProtein(int protein) {
+        this.protein = protein;
+    }
+}

--- a/app/src/main/java/com/teamfive/caltrack/database/entities/Goals.java
+++ b/app/src/main/java/com/teamfive/caltrack/database/entities/Goals.java
@@ -1,0 +1,111 @@
+package com.teamfive.caltrack.database.entities;
+
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+import androidx.room.ColumnInfo;
+import androidx.room.TypeConverters;
+
+import com.teamfive.caltrack.database.helpers.Converters;
+
+import java.util.Date;
+
+@Entity(tableName = "goals")
+public class Goals {
+
+    @PrimaryKey(autoGenerate = true)
+    private int id;
+
+    @ColumnInfo(name = "start_date")
+    @TypeConverters(Converters.class) // Converts Date to Long for Room
+    private Date startDate;
+
+    @ColumnInfo(name = "end_date")
+    @TypeConverters(Converters.class)
+    private Date endDate;
+
+    @ColumnInfo(name = "goal_calories")
+    private int goalCalories;
+
+    @ColumnInfo(name = "goal_carbs")
+    private int goalCarbs;
+
+    @ColumnInfo(name = "goal_fat")
+    private int goalFat;
+
+    @ColumnInfo(name = "goal_protein")
+    private int goalProtein;
+
+    /**
+     * Constructor
+     * @param goalCalories
+     * @param goalCarbs
+     * @param goalFat
+     * @param goalProtein
+     */
+    public Goals(int goalCalories, int goalCarbs, int goalFat, int goalProtein) {
+        this.startDate = new Date();
+        this.endDate = null;
+        this.goalCalories = goalCalories;
+        this.goalCarbs = goalCarbs;
+        this.goalFat = goalFat;
+        this.goalProtein = goalProtein;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public Date getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(Date startDate) {
+        this.startDate = startDate;
+    }
+
+    public Date getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(Date endDate) {
+        this.endDate = endDate;
+    }
+
+    public int getGoalCalories() {
+        return goalCalories;
+    }
+
+    public void setGoalCalories(int goalCalories) {
+        this.goalCalories = goalCalories;
+    }
+
+    public int getGoalCarbs() {
+        return goalCarbs;
+    }
+
+    public void setGoalCarbs(int goalCarbs) {
+        this.goalCarbs = goalCarbs;
+    }
+
+    public int getGoalFat() {
+        return goalFat;
+    }
+
+    public void setGoalFat(int goalFat) {
+        this.goalFat = goalFat;
+    }
+
+    public int getGoalProtein() {
+        return goalProtein;
+    }
+
+    public void setGoalProtein(int goalProtein) {
+        this.goalProtein = goalProtein;
+    }
+
+    // Getters and setters
+}

--- a/app/src/main/java/com/teamfive/caltrack/database/helpers/Converters.java
+++ b/app/src/main/java/com/teamfive/caltrack/database/helpers/Converters.java
@@ -1,0 +1,17 @@
+package com.teamfive.caltrack.database.helpers;
+
+import androidx.room.TypeConverter;
+import java.util.Date;
+
+public class Converters {
+
+    @TypeConverter
+    public static Date fromTimestamp(Long value) {
+        return value == null ? null : new Date(value);
+    }
+
+    @TypeConverter
+    public static Long dateToTimestamp(Date date) {
+        return date == null ? null : date.getTime();
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,9 @@ lifecycleLivedataKtx = "2.8.5"
 lifecycleViewmodelKtx = "2.8.5"
 navigationFragment = "2.6.0"
 navigationUi = "2.6.0"
+roomCommon = "2.6.1"
+roomRuntime = "2.6.1"
+roomCompiler = "2.6.1"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -22,6 +25,9 @@ lifecycle-livedata-ktx = { group = "androidx.lifecycle", name = "lifecycle-lived
 lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycleViewmodelKtx" }
 navigation-fragment = { group = "androidx.navigation", name = "navigation-fragment", version.ref = "navigationFragment" }
 navigation-ui = { group = "androidx.navigation", name = "navigation-ui", version.ref = "navigationUi" }
+room-common = { group = "androidx.room", name = "room-common", version.ref = "roomCommon" }
+room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "roomRuntime" }
+room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "roomCompiler" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This commit adds three database tables: daily_logs, food_logs, and goals. 

daily_logs: This is an entry for each date. It includes the date, goals (protein, carbs, calories, fat) for that day as well as any other data we want to include like a note (called journal). 

food_logs: This is an entry for every food item the user inputs. It includes the name of the food, the nutritional stats (protein, carbs, calories, fat) and probably will include the UPC or something when we get scanner working.

goals: This includes timeframes of goals. For example, if the user sets their goal to be 2000 calories, (200g protein, etc. ) this table will say the goals for any daily_logs in between start_date field and end_date field (null if it's the current goal) should be this. This is necessary because if the user does misses a day of inputting a food log and wants to go view that date, we should at least be able to show that they were 0% of their goal, this makes sure that we have a goal to show.